### PR TITLE
Updated for PHP 8.1 compatibility.

### DIFF
--- a/third_party/MX/Loader.php
+++ b/third_party/MX/Loader.php
@@ -297,7 +297,9 @@ class MX_Loader extends CI_Loader
 			$view = $_view;
 		}
 
-		return $this->_ci_load(array('_ci_view' => $view, '_ci_vars' => $this->_ci_object_to_array($vars), '_ci_return' => $return));
+		return (version_compare(CI_VERSION, '3.1.3', '<=')) ?
+			$this->_ci_load(array('_ci_view' => $view, '_ci_vars' => $this->_ci_object_to_array($vars), '_ci_return' => $return)) :
+			$this->_ci_load(array('_ci_view' => $view, '_ci_vars' => $this->_ci_prepare_view_vars($vars), '_ci_return' => $return));
 	}
 
 	protected function &_ci_get_component($component)

--- a/third_party/MX/Modules.php
+++ b/third_party/MX/Modules.php
@@ -25,18 +25,18 @@ spl_autoload_register('Modules::autoload');
  * Install this file as application/third_party/MX/Modules.php
  *
  * @copyright	Copyright (c) 2015 Wiredesignz
- * @version 	5.5
- * 
+ * @version 	5.5.1
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,23 +48,23 @@ spl_autoload_register('Modules::autoload');
 class Modules
 {
 	public static $routes, $registry, $locations;
-	
+
 	/**
 	* Run a module controller method
 	* Output from module is buffered and returned.
 	**/
-	public static function run($module) 
-	{	
+	public static function run($module)
+	{
 		$method = 'index';
-		
-		if(($pos = strrpos($module, '/')) != FALSE) 
+
+		if(($pos = strrpos($module, '/')))
 		{
-			$method = substr($module, $pos + 1);		
+			$method = substr($module, $pos + 1);
 			$module = substr($module, 0, $pos);
 		}
 
-		if($class = self::load($module)) 
-		{	
+		if($class = self::load($module))
+		{
 			if (method_exists($class, $method))	{
 				ob_start();
 				$args = func_get_args();
@@ -73,130 +73,129 @@ class Modules
 				return ($output !== NULL) ? $output : $buffer;
 			}
 		}
-		
-		log_message('error', "Module controller failed to run: {$module}/{$method}");
+
+		 log_message('error', "Module controller failed to run: $module/$method");
 	}
-	
+
 	/** Load a module controller **/
-	public static function load($module) 
+	public static function load($module)
 	{
-		(is_array($module)) ? list($module, $params) = each($module) : $params = NULL;	
-		
+		(is_array($module)) ? list($module, $params) = [array_key_first($module), array_pop($module)] : $params = NULL;
+
 		/* get the requested controller class name */
 		$alias = strtolower(basename($module));
 
 		/* create or return an existing controller from the registry */
-		if ( ! isset(self::$registry[$alias])) 
+		if ( ! isset(self::$registry[$alias]))
 		{
 			/* find the controller */
 			list($class) = CI::$APP->router->locate(explode('/', $module));
-	
+
 			/* controller cannot be located */
 			if (empty($class)) return;
-	
+
 			/* set the module directory */
 			$path = APPPATH.'controllers/'.CI::$APP->router->directory;
-			
+
 			/* load the controller class */
 			$class = $class.CI::$APP->config->item('controller_suffix');
 			self::load_file(ucfirst($class), $path);
-			
+
 			/* create and register the new controller */
-			$controller = ucfirst($class);	
+			$controller = ucfirst($class);
 			self::$registry[$alias] = new $controller($params);
 		}
-		
+
 		return self::$registry[$alias];
 	}
-	
+
 	/** Library base class autoload **/
-	public static function autoload($class) 
-	{	
+	public static function autoload($class): void
+	{
 		/* don't autoload CI_ prefixed classes or those using the config subclass_prefix */
 		if (strstr($class, 'CI_') OR strstr($class, config_item('subclass_prefix'))) return;
 
 		/* autoload Modular Extensions MX core classes */
-		if (strstr($class, 'MX_')) 
+		if (str_contains($class, 'MX_'))
 		{
-			if (is_file($location = dirname(__FILE__).'/'.substr($class, 3).EXT)) 
+			if (is_file($location = dirname(__FILE__).'/'.substr($class, 3).EXT))
 			{
 				include_once $location;
 				return;
 			}
 			show_error('Failed to load MX core class: '.$class);
 		}
-		
+
 		/* autoload core classes */
-		if(is_file($location = APPPATH.'core/'.ucfirst($class).EXT)) 
+		if(is_file($location = APPPATH.'core/'.ucfirst($class).EXT))
 		{
 			include_once $location;
 			return;
-		}		
-		
+		}
+
 		/* autoload library classes */
-		if(is_file($location = APPPATH.'libraries/'.ucfirst($class).EXT)) 
+		if(is_file($location = APPPATH.'libraries/'.ucfirst($class).EXT))
 		{
 			include_once $location;
-			return;
-		}		
+		}
 	}
 
 	/** Load a module file **/
-	public static function load_file($file, $path, $type = 'other', $result = TRUE)	
+	public static function load_file($file, $path, $type = 'other', $result = TRUE)
 	{
-		$file = str_replace(EXT, '', $file);		
+		$file = str_replace(EXT, '', $file);
 		$location = $path.$file.EXT;
-		
-		if ($type === 'other') 
-		{			
-			if (class_exists($file, FALSE))	
+
+		if ($type === 'other')
+		{
+			if (class_exists($file, FALSE))
 			{
-				log_message('debug', "File already loaded: {$location}");				
+				log_message('debug', "File already loaded: $location");
 				return $result;
-			}	
+			}
 			include_once $location;
-		} 
-		else 
+		}
+		else
 		{
 			/* load config or language array */
 			include $location;
 
-			if ( ! isset($$type) OR ! is_array($$type))				
-				show_error("{$location} does not contain a valid {$type} array");
+			if ( ! isset($$type) OR ! is_array($$type))
+				show_error("$location does not contain a valid $type array");
 
 			$result = $$type;
 		}
-		log_message('debug', "File loaded: {$location}");
+		log_message('debug', "File loaded: $location");
 		return $result;
 	}
 
-	/** 
+	/**
 	* Find a file
 	* Scans for files located within modules directories.
 	* Also scans application directories for models, plugins and views.
 	* Generates fatal error if file not found.
 	**/
-	public static function find($file, $module, $base) 
+	public static function find($file, $module, $base)
 	{
 		$segments = explode('/', $file);
 
 		$file = array_pop($segments);
 		$file_ext = (pathinfo($file, PATHINFO_EXTENSION)) ? $file : $file.EXT;
-		
-		$path = ltrim(implode('/', $segments).'/', '/');	
+
+		$path = ltrim(implode('/', $segments).'/', '/');
 		$module ? $modules[$module] = $path : $modules = array();
-		
-		if ( ! empty($segments)) 
+
+		if ( ! empty($segments))
 		{
 			$modules[array_shift($segments)] = ltrim(implode('/', $segments).'/','/');
-		}	
+		}
 
-		foreach (Modules::$locations as $location => $offset) 
-		{					
-			foreach($modules as $module => $subpath) 
-			{			
+		foreach (Modules::$locations as $location => $offset)
+		{
+			foreach($modules as $module => $subpath)
+			{
 				$fullpath = $location.$module.'/'.$base.$subpath;
-				
+
 				if ($base == 'libraries/' OR $base == 'models/')
 				{
 					if(is_file($fullpath.ucfirst($file_ext))) return array($fullpath, ucfirst($file));
@@ -231,7 +230,7 @@ class Modules
 			
 			if (preg_match('#^'.$key.'$#', $uri)) 
 			{							
-				if (strpos($val, '$') !== FALSE AND strpos($key, '(') !== FALSE) 
+				if (str_contains($val, '$') AND str_contains($key, '('))
 				{
 					$val = preg_replace('#^'.$key.'$#', $val, $uri);
 				}

--- a/third_party/MX/Router.php
+++ b/third_party/MX/Router.php
@@ -236,7 +236,7 @@ class MX_Router extends CI_Router
 	public function set_class($class)
 	{
 		$suffix = $this->config->item('controller_suffix');
-		if (strpos($class, $suffix) === FALSE)
+		if ( ! is_null($suffix) && strpos($class, $suffix) === FALSE)
 		{
 			$class .= $suffix;
 		}


### PR DESCRIPTION
This PR addresses two specific issues:

1. **_ci_object_to_array error in CodeIgniter 3.1.13+**: Starting from version 3.1.13 of CodeIgniter, the `_ci_object_to_array` function was deprecated and removed. This caused compatibility issues in older codebases. The fix ensures the application is compatible with newer versions of CodeIgniter by replacing or removing references to the deprecated function.

2. **strpos() warning in PHP 8.1+**: In PHP 8.1+, passing `null` as the second parameter (`$needle`) to the `strpos()` function results in a deprecation warning. This issue has been addressed by ensuring that a string is always passed as `$needle`, preventing the warning and maintaining compatibility with PHP 8.1+.

These changes improve the application's stability and ensure compatibility with the latest versions of CodeIgniter and PHP.